### PR TITLE
allow to specify at which break token occurence to truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ TruncateHtml.configure do |config|
   config.break_token = '<!-- truncate -->'
 end
 ```
+
+You can specify at which `:break_token` occurance to truncate the HTML. By default it is
+the very first occurance of `:break_token`. When there is no `:break_token` then
+`:break_token_at_count` has no effect.
+
+```ruby
+TruncateHtml.configure do |config|
+  config.break_token = '</p>'
+  config.break_token_at_count = 3
+```
 Installation
 ------------
 

--- a/lib/truncate_html/configuration.rb
+++ b/lib/truncate_html/configuration.rb
@@ -1,6 +1,6 @@
 module TruncateHtml
   class Configuration
-    attr_accessor :length, :omission, :word_boundary, :break_token
+    attr_accessor :length, :omission, :word_boundary, :break_token, :break_token_at_count
   end
 
   class << self

--- a/lib/truncate_html/html_truncator.rb
+++ b/lib/truncate_html/html_truncator.rb
@@ -1,20 +1,24 @@
 module TruncateHtml
   class HtmlTruncator
-
     def initialize(original_html, options = {})
-      @original_html   = original_html
-      length           = options[:length]       || TruncateHtml.configuration.length
-      @omission        = options[:omission]     || TruncateHtml.configuration.omission
-      @word_boundary   = (options.has_key?(:word_boundary) ? options[:word_boundary] : TruncateHtml.configuration.word_boundary)
-      @break_token     = options[:break_token] || TruncateHtml.configuration.break_token || nil
-      @chars_remaining = length - @omission.length
+      @original_html        = original_html
+      length                = options[:length]       || TruncateHtml.configuration.length
+      @omission             = options[:omission]     || TruncateHtml.configuration.omission
+      @word_boundary        = (options.has_key?(:word_boundary) ? options[:word_boundary] : TruncateHtml.configuration.word_boundary)
+      @break_token          = options[:break_token] || TruncateHtml.configuration.break_token || nil
+      @break_token_at_count = options[:break_token_at_count] || TruncateHtml.configuration.break_token_at_count || 1
+      @chars_remaining      = length - @omission.length
       @open_tags, @closing_tags, @truncated_html = [], [], ['']
     end
 
     def truncate
       return @omission if @chars_remaining < 0
+
+      break_token_counter = 0
       @original_html.html_tokens.each do |token|
-        if @chars_remaining <= 0 || truncate_token?(token)
+        break_token_counter += 1 if truncate_token?(token)
+
+        if @chars_remaining <= 0 || @break_token_at_count == break_token_counter
           close_open_tags
           break
         else

--- a/spec/truncate_html/html_truncator_spec.rb
+++ b/spec/truncate_html/html_truncator_spec.rb
@@ -198,6 +198,18 @@ This is ugly html.
     end
   end
 
+  context 'when break_token_at_count not set for break_token' do
+    it 'truncates at first break token' do
+      truncate('This is line one. This is line <break /> two.', break_token: '<break />').should == 'This is line one. This is line'
+    end
+  end
+
+  context 'when break_token_at_count is set for break_token' do
+    it 'truncates at specified break_token occurance' do
+      truncate('This is line one. This is line <break /> two. This <break /> is line <break /> three.', break_token: '<break />', break_token_at_count: 3).should == 'This is line one. This is line <break /> two. This <break /> is line'
+    end
+  end
+
   context 'a string with comments' do
     it 'does not duplicate comments (issue #32)' do
       truncate('<h1>hello <!-- stuff --> and <!-- la --> goodbye</h1>', length: 15).should ==


### PR DESCRIPTION
Extends `:break_token` configuration with `:break_token_at_count` which allows to specify at which  occurrence of `:break_token` to truncate HTML.

Possible use case: truncate first 3 paragraphs.

```ruby
TruncateHtml.configure do |config|
  config.break_token = '</p>'
  config.break_token_at_count = 3
end
```